### PR TITLE
Fix trailing newline in secret for sample stateful-mysql

### DIFF
--- a/stateful-mysql/secret.yaml
+++ b/stateful-mysql/secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: mysql-secret
 type: Opaque
 data:
-  password: WU9VUl9QQVNTV09SRAo= # YOUR_PASSWORD
-  admin-password: WU9VUl9QQVNTV09SRAo= # YOUR_PASSWORD
+  password: WU9VUl9QQVNTV09SRA== # YOUR_PASSWORD
+  admin-password: WU9VUl9QQVNTV09SRAo== # YOUR_PASSWORD


### PR DESCRIPTION
The secret of example stateful-mysql generated by `echo 'secret' | base64`, which automatically inserts a trailing newline, leads to this error `mysql: unknown option '--"'`. Regenerate it by `echo -n 'secret' | base64`.

Refer to https://stackoverflow.com/questions/62985541/mysql-unknown-option-in-kubernetes for details.